### PR TITLE
look manager select assigned objects button

### DIFF
--- a/capito/maya/render/look_manager.py
+++ b/capito/maya/render/look_manager.py
@@ -134,6 +134,9 @@ class LookManager(QMainWindow):
         select_btn = QPushButton("Select Objects")
         select_btn.clicked.connect(self.select_objects)
         button_box.addWidget(select_btn)
+        select_assign_btn = QPushButton("Select Assigned Objects")
+        select_assign_btn.clicked.connect(self.select_assigned_objects)
+        button_box.addWidget(select_assign_btn)
         assign_btn = QPushButton("Assign to Selection")
         assign_btn.clicked.connect(self.assign)
         button_box.addWidget(assign_btn)
@@ -183,6 +186,12 @@ class LookManager(QMainWindow):
         for item in items:
             look = item.data(Qt.UserRole)
             look.select_objects()
+
+    def select_assigned_objects(self):
+        items = self.look_list.selectedItems()
+        for item in items:
+            look = item.data(Qt.UserRole)
+            look.select_assigned_objects()
     
     def assign(self):
         items = self.look_list.selectedItems()
@@ -206,7 +215,7 @@ class LookManager(QMainWindow):
         items = self.look_list.selectedItems()
         for item in items:
             look = item.data(Qt.UserRole)
-            look.select_objects()
+            look.select_assigned_objects()
             pc.mel.eval("sets -e -forceElement initialShadingGroup;")
             
             to_delete = []

--- a/capito/maya/render/looks.py
+++ b/capito/maya/render/looks.py
@@ -186,6 +186,14 @@ class Look:
                 objects.extend(pc.ls(regex=f"*{obj}"))
             pc.select(objects)
 
+    def select_assigned_objects(self):
+        objects = []
+        shading_groups = self.shadingGroups
+        for sg in shading_groups:
+            sets = pc.sets(sg, q=True)
+            objects.extend(sets)
+        pc.select(objects)
+
     @property
     def shadingGroups(self):
         """Return all shading groups associated with this look node."""


### PR DESCRIPTION
Change Notes:

- Added a Button `Assign to Selection` to the look manager ui, that selects objects where the selected look has been assigned
- Added a method `select_assigned_objects()` to Look class, that selects objects where the look has ben assigned to via its shading group sets
- Changed `delete()` method of look_manager.py, so that it only removes looks from assigned objects. Before, this method used to remove all looks from objects with names matching to the look-specific object names, regardless of the actual look that has been assigned to them. 